### PR TITLE
updated `abcd exec` examples

### DIFF
--- a/examples.md
+++ b/examples.md
@@ -50,9 +50,9 @@ abcd download -q 'formula~"W128"' -f xyz data.xyz
 
 executing commands on all configurations that match a query:
 ```
-abcd exec -q 'formula~"W128"' 'print(item.info.cell)'
-abcd exec -q 'formula~"W128"' 'print(item.info.cell)' --yes
-abcd exec -q 'formula~"W128"' 'at=item.to_atoms(); print(at.cell)' --yes
+abcd exec -q 'formula~"W128"' 'print(atoms.to_ase().cell)'
+abcd exec -q 'formula~"W128"' 'print(atoms.to_ase().cell)' --yes
+abcd exec -q 'formula~"W128"' 'at=atoms.to_ase(); print(at.cell)' --yes
 ```
 ```
 abcd exec  'atoms["energy_per_atom"] = atoms["energy"]/atoms["n_atoms"] ; atoms.save()' --yes


### PR DESCRIPTION
Updated some examples. For example, in `abcd exec -q 'formula~"W128"' 'print(item.info.cell)' --yes` ` info` is not recognised, `atoms` must be used instead: 

```
$ abcd exec -q "config_type='ethanol_mol'" -q "dataset_type='dft_opt_bde_test'" "print(item.info)" --yes
(('EQ', ('NAME', 'config_type'), ('STRING', 'ethanol_mol')), ('EQ', ('NAME', 'dataset_type'), ('STRING', 'dft_opt_bde_test')))
Traceback (most recent call last):
  File "/opt/womble/miniconda3/user_envs/eg475/wo/bin/abcd", line 33, in <module>
    sys.exit(load_entry_point('abcd', 'console_scripts', 'abcd')())
  File "/home/eg475/programs/abcd/abcd/frontends/commandline/parser.py", line 121, in main
    callback_func(**kwargs)
  File "/home/eg475/programs/abcd/abcd/frontends/commandline/decorators.py", line 59, in wrapper
    func(*args, **kwargs)
  File "/home/eg475/programs/abcd/abcd/frontends/commandline/decorators.py", line 15, in wrapper
    func(*args, config=config, **kwargs)
  File "/home/eg475/programs/abcd/abcd/frontends/commandline/decorators.py", line 48, in wrapper
    func(*args, db=db, query=query, **kwargs)
  File "/home/eg475/programs/abcd/abcd/frontends/commandline/commands.py", line 229, in execute
    db.exec(python_code, query)
  File "/home/eg475/programs/abcd/abcd/backends/atoms_pymongo.py", line 408, in exec
    exec(code)
  File "<string>", line 1, in <module>
NameError: name 'item' is not defined
```

Also, `items.to_atoms()` -> `atoms.to_ase()` and `cell` is an  ASE `atoms` attribute, not `atoms.info`

```
$ abcd exec -q "config_type='ethanol_mol'" -q "dataset_type='dft_opt_bde_test'" "print(atoms.to_ase().cell)" --yes
(('EQ', ('NAME', 'config_type'), ('STRING', 'ethanol_mol')), ('EQ', ('NAME', 'dataset_type'), ('STRING', 'dft_opt_bde_test')))
Cell([50.0, 50.0, 50.0])
Cell([50.0, 50.0, 50.0])
Cell([50.0, 50.0, 50.0])
```