### PR TITLE
Fix data model

### DIFF
--- a/abcd/model.py
+++ b/abcd/model.py
@@ -241,6 +241,7 @@ class AbstractModel(UserDict):
             # atoms.calc = get_calculator(data['results']['calculator_name'])(**params)
 
             params = self.pop("calculator_parameters", {})
+            info_keys -= {"calculator_parameters"}
 
             atoms.calc = SinglePointCalculator(atoms, **params)
             atoms.calc.results.update((key, self[key]) for key in results_keys)

--- a/abcd/model.py
+++ b/abcd/model.py
@@ -159,9 +159,10 @@ class AbstractModel(UserDict):
         }
         arrays_keys = set(atoms.arrays.keys())
         info_keys = set(atoms.info.keys())
-        results_keys = (
-            set(atoms.calc.results.keys()) if store_calc and atoms.calc else {}
-        )
+        if store_calc and atoms.calc:
+            results_keys = atoms.calc.results.keys() - (arrays_keys | info_keys)
+        else:
+            results_keys = {}
 
         all_keys = (reserved_keys, arrays_keys, info_keys, results_keys)
         if len(set.union(*all_keys)) != sum(map(len, all_keys)):

--- a/abcd/model.py
+++ b/abcd/model.py
@@ -204,10 +204,6 @@ class AbstractModel(UserDict):
 
             for key, value in atoms.calc.results.items():
                 if isinstance(value, np.ndarray):
-                    if value.shape[0] == n_atoms:
-                        arrays_keys.add(key)
-                    else:
-                        info_keys.add(key)
                     data[key] = value.tolist()
                 else:
                     data[key] = value
@@ -261,14 +257,14 @@ class AbstractModel(UserDict):
 
         if cell:
             volume = abs(np.linalg.det(cell))  # atoms.get_volume()
-            self["volume"] = volume
             self.derived_keys.append("volume")
+            self["volume"] = volume
 
             virial = self.get("virial")
             if virial:
                 # pressure P = -1/3 Tr(stress) = -1/3 Tr(virials/volume)
-                self["pressure"] = -1 / 3 * np.trace(virial / volume)
                 self.derived_keys.append("pressure")
+                self["pressure"] = -1 / 3 * np.trace(virial / volume)
 
         # 'elements': Counter(atoms.get_chemical_symbols()),
         self["elements"] = Counter(str(element) for element in self["numbers"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ numpy = "^1.26"
 tqdm = "^4.66"
 pymongo = "^4.7.3"
 matplotlib = "^3.9"
-ase = "3.22.1"
+ase = "^3.23"
 lark = "^1.1.9"
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_abstract_model.py
+++ b/tests/test_abstract_model.py
@@ -11,7 +11,7 @@ from abcd.model import AbstractModel
 def extxyz_file():
     return StringIO(
         """2
-        Properties=species:S:1:pos:R:3:forces:R:3 energy=-1 pbc="F T F"
+        Properties=species:S:1:pos:R:3:forces:R:3 energy=-1 pbc="F T F" info="test"
         Si  0.0  0.0  0.0  0.4  0.6  -0.4
         Si  0.0  0.0  0.0  -0.1  -0.5  -0.6
         """
@@ -35,6 +35,7 @@ def test_from_atoms(extxyz_file):
         "formula",
         "calculator_name",
         "calculator_parameters",
+        "info",
     }
     assert info_keys == set(data.info_keys)
     assert data["pbc"] == [False, True, False]
@@ -42,6 +43,7 @@ def test_from_atoms(extxyz_file):
     assert len(data["cell"]) == 3
     assert all(arr == [0.0, 0.0, 0.0] for arr in data["cell"])
     assert data["formula"] == "Si2"
+    assert data["info"] == "test"
 
     # Test arrays
     assert {"numbers", "positions"} == set(data.arrays_keys)
@@ -74,12 +76,13 @@ def test_from_atoms_no_calc(extxyz_file):
     data = AbstractModel.from_atoms(atoms, store_calc=False)
 
     # Test info
-    assert {"pbc", "n_atoms", "cell", "formula"} == set(data.info_keys)
+    assert {"pbc", "n_atoms", "cell", "formula", "info"} == set(data.info_keys)
     assert data["pbc"] == [False, True, False]
     assert data["n_atoms"] == 2
     assert len(data["cell"]) == 3
     assert all(arr == [0.0, 0.0, 0.0] for arr in data["cell"])
     assert data["formula"] == "Si2"
+    assert data["info"] == "test"
 
     # Test arrays
     assert {"numbers", "positions"} == set(data.arrays_keys)
@@ -105,3 +108,46 @@ def test_from_atoms_no_calc(extxyz_file):
         "hash_structure",
     }
     assert derived_keys == set(data.derived_keys)
+
+
+def test_to_ase(extxyz_file):
+    """Test returning data to ASE Atoms object with results."""
+    atoms = read(extxyz_file, format="extxyz")
+    data = AbstractModel.from_atoms(atoms, store_calc=True)
+
+    new_atoms = data.to_ase()
+
+    # Test info set
+    assert new_atoms.cell == pytest.approx(atoms.cell)
+    assert new_atoms.pbc == pytest.approx(atoms.pbc)
+    assert new_atoms.positions == pytest.approx(atoms.positions)
+    assert new_atoms.numbers == pytest.approx(atoms.numbers)
+
+    assert new_atoms.info["n_atoms"] == len(atoms)
+    assert new_atoms.info["formula"] == atoms.get_chemical_formula()
+
+    assert new_atoms.calc.results["energy"] == pytest.approx(
+        atoms.calc.results["energy"]
+    )
+    assert new_atoms.calc.results["forces"] == pytest.approx(
+        atoms.calc.results["forces"]
+    )
+
+
+def test_to_ase_no_results(extxyz_file):
+    """Test returning data to ASE Atoms object without results."""
+    atoms = read(extxyz_file, format="extxyz")
+    data = AbstractModel.from_atoms(atoms, store_calc=False)
+
+    new_atoms = data.to_ase()
+
+    # Test info set
+    assert new_atoms.cell == pytest.approx(atoms.cell)
+    assert new_atoms.pbc == pytest.approx(atoms.pbc)
+    assert new_atoms.positions == pytest.approx(atoms.positions)
+    assert new_atoms.numbers == pytest.approx(atoms.numbers)
+
+    assert new_atoms.info["n_atoms"] == len(atoms)
+    assert new_atoms.info["formula"] == atoms.get_chemical_formula()
+
+    assert new_atoms.calc is None

--- a/tests/test_abstract_model.py
+++ b/tests/test_abstract_model.py
@@ -1,0 +1,107 @@
+import pytest
+
+from io import StringIO
+from ase.io import read
+import numpy as np
+
+from abcd.model import AbstractModel
+
+
+@pytest.fixture
+def extxyz_file():
+    return StringIO(
+        """2
+        Properties=species:S:1:pos:R:3:forces:R:3 energy=-1 pbc="F T F"
+        Si  0.0  0.0  0.0  0.4  0.6  -0.4
+        Si  0.0  0.0  0.0  -0.1  -0.5  -0.6
+        """
+    )
+
+
+def test_from_atoms(extxyz_file):
+    """Test extracting data from ASE Atoms object."""
+    expected_forces = np.array([[0.4, 0.6, -0.4], [-0.1, -0.5, -0.6]])
+    expected_stress = np.array([-1.0, -1.0, -1.0, -2.1, 2.0, 1.8])
+
+    atoms = read(extxyz_file, format="extxyz")
+    atoms.calc.results["stress"] = expected_stress
+    data = AbstractModel.from_atoms(atoms)
+
+    # Test info
+    info_keys = {
+        "pbc",
+        "n_atoms",
+        "cell",
+        "formula",
+        "calculator_name",
+        "calculator_parameters",
+    }
+    assert info_keys == set(data.info_keys)
+    assert data["pbc"] == [False, True, False]
+    assert data["n_atoms"] == 2
+    assert len(data["cell"]) == 3
+    assert all(arr == [0.0, 0.0, 0.0] for arr in data["cell"])
+    assert data["formula"] == "Si2"
+
+    # Test arrays
+    assert {"numbers", "positions"} == set(data.arrays_keys)
+
+    # Test results
+    assert {"energy", "stress", "forces"} == set(data.results_keys)
+    assert data["energy"] == -1
+    assert data["forces"] == pytest.approx(expected_forces)
+    assert data["stress"] == pytest.approx(expected_stress)
+
+    # Test derived
+    derived_keys = {
+        "elements",
+        "username",
+        "uploaded",
+        "modified",
+        "volume",
+        "hash",
+        "hash_structure",
+    }
+    assert derived_keys == set(data.derived_keys)
+
+
+def test_from_atoms_no_calc(extxyz_file):
+    """Test extracting data from ASE Atoms object without results."""
+    expected_stress = np.array([-1.0, -1.0, -1.0, -2.1, 2.0, 1.8])
+
+    atoms = read(extxyz_file, format="extxyz")
+    atoms.calc.results["stress"] = expected_stress
+    data = AbstractModel.from_atoms(atoms, store_calc=False)
+
+    # Test info
+    assert {"pbc", "n_atoms", "cell", "formula"} == set(data.info_keys)
+    assert data["pbc"] == [False, True, False]
+    assert data["n_atoms"] == 2
+    assert len(data["cell"]) == 3
+    assert all(arr == [0.0, 0.0, 0.0] for arr in data["cell"])
+    assert data["formula"] == "Si2"
+
+    # Test arrays
+    assert {"numbers", "positions"} == set(data.arrays_keys)
+
+    # Test results
+    results_keys = {
+        "energy",
+        "forces",
+        "stress",
+        "calculator_name",
+        "calculator_parameters",
+    }
+    assert all(key not in data for key in results_keys)
+
+    # Test derived
+    derived_keys = {
+        "elements",
+        "username",
+        "uploaded",
+        "modified",
+        "volume",
+        "hash",
+        "hash_structure",
+    }
+    assert derived_keys == set(data.derived_keys)

--- a/tests/test_abstract_model.py
+++ b/tests/test_abstract_model.py
@@ -189,7 +189,7 @@ def test_from_atoms_len_atoms_3():
         "free_energy",
     }
 
-    # check a some keys as well
+    # check some values as well
     assert abcd_data["energy"] == atoms.get_potential_energy()
     assert abcd_data["forces"] == approx(atoms.get_forces())
 


### PR DESCRIPTION
Introduces various fixes, mostly relating to converting data to and from `Atoms.calc.results`:

- Updates ASE to 3.23+, due to changes in how various quantities are stored (e.g. previously, `energy` would also be stored in `Atoms.info`)
  - I think all changes are still valid for 3.22.1, but the tests would fail due to differences in how values are stored.

`from_atoms`:

- Ensures keys are not duplicated between `info` and `results`, which previously caused errors when pushing/uploading with `store_calc`.
- Removed adding `results` to `info` and `array` keys unnecessarily
  - This also fixes a bug where, for example `arrays_keys.update(key)` splits `key` into individual letters, rather than adding the entire key to the set

`to_ase`:

- Fixes setting keys (and when they are set) when dealing with calculated results, to avoid mislabelling/missing key errors.