### PR TITLE
Fix hashing

### DIFF
--- a/abcd/model.py
+++ b/abcd/model.py
@@ -12,8 +12,8 @@ logger = logging.getLogger(__name__)
 
 
 class Hasher(object):
-    def __init__(self, method=md5()):
-        self.method = method
+    def __init__(self, method=md5):
+        self.method = method()
 
     def update(self, value):
 
@@ -273,26 +273,25 @@ class AbstractModel(UserDict):
         self["username"] = getpass.getuser()
 
         if not self.get("uploaded"):
-            self["uploaded"] = datetime.datetime.utcnow()
+            self["uploaded"] = datetime.datetime.now(datetime.timezone.utc)
 
-        self["modified"] = datetime.datetime.utcnow()
+        self["modified"] = datetime.datetime.now(datetime.timezone.utc)
 
-        m = Hasher()
+        hasher = Hasher()
 
         for key in ("numbers", "positions", "cell", "pbc"):
-            m.update(self[key])
+            hasher.update(self[key])
 
         self.derived_keys.append("hash_structure")
-        self["hash_structure"] = m()
+        self["hash_structure"] = hasher()
 
-        m = Hasher()
         for key in self.arrays_keys:
-            m.update(self[key])
+            hasher.update(self[key])
         for key in self.info_keys:
-            m.update(self[key])
+            hasher.update(self[key])
 
         self.derived_keys.append("hash")
-        self["hash"] = m()
+        self["hash"] = hasher()
 
 
 if __name__ == "__main__":

--- a/tests/test_abstract_model.py
+++ b/tests/test_abstract_model.py
@@ -255,6 +255,15 @@ def test_write_and_read(store_calc):
         ), f"{key}'s value does not match"
 
 
+def test_hash_update():
+    """Test hash can be updated after initialisation."""
+    hasher_1 = Hasher()
+
+    init_hash = hasher_1()
+    hasher_1.update("Test value")
+    assert hasher_1() != init_hash
+
+
 @pytest.mark.parametrize(
     "data",
     [
@@ -267,25 +276,46 @@ def test_write_and_read(store_calc):
         b"test",
     ],
 )
-def test_hasher(data):
-    """Test hash calculated correctly."""
+def test_hash_data_types(data):
+    """Test updating hash for different data types."""
     hasher_1 = Hasher()
-
-    # Test hash updated
-    init_hash = hasher_1()
     hasher_1.update("Test value")
     updated_hash = hasher_1()
-    assert updated_hash != init_hash
 
-    # Test updating hash for different data types
     hasher_1.update(data)
     assert updated_hash != hasher_1()
 
-    # Test newer hasher reset correctly
+
+def test_second_hash_init():
+    """Test second hash is initialised correctly."""
+    hasher_1 = Hasher()
+
+    init_hash = hasher_1()
+    hasher_1.update("Test value")
+
     hasher_2 = Hasher()
     assert hasher_2() == init_hash
 
-    # Test hashes match after same data added
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        1296,
+        3.14,
+        [1, 2, 3],
+        (4, 5, 6),
+        {"a": "value"},
+        datetime.datetime.now(datetime.timezone.utc),
+        b"test",
+    ],
+)
+def test_consistent_hash(data):
+    """Test two hashers agree with same data."""
+    hasher_1 = Hasher()
+    hasher_1.update("Test value")
+    hasher_1.update(data)
+
+    hasher_2 = Hasher()
     hasher_2.update("Test value")
     hasher_2.update(data)
     assert hasher_1() == hasher_2()


### PR DESCRIPTION
- Fixes the hasher definition, as discussed in the issue.
  - I've removed the second creation of a hasher object, which means the overall hash is similar to the erroneous behaviour before, in that the structure hash contributes to the final hash.

- Also updates the deprecated `utcnow`, and tidies the code slightly.

Edit: `hash_strucutre` seems fixed in `test_write_and_read`, but actually I'm not sure the example in the issue quite works yet, so I'll leave this as a draft for now.